### PR TITLE
Add feature for semi-comp games to allow spectating

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ before spawning in themselves.
   * Older versions of the nt_competitive plugin use their own built-in (inferior) fade system, which may interfere with this plugin
 
 ## Usage
-Set the cvar value `mp_forcecamera 1` to enable this plugin. The [nt_competitive plugin](https://github.com/Rainyan/sourcemod-nt-competitive) sets this cvar value automatically when going live, so you don't need to do anything if using these plugins in tandem.
+Set the cvar value `mp_forcecamera 1` and `sm_competitive_fade_enabled 1` to enable this plugin. The [nt_competitive plugin](https://github.com/Rainyan/sourcemod-nt-competitive) sets this cvar value automatically when going live, so you don't need to do anything if using these plugins in tandem.  
+
+Set the cvar value `mp_forcecamera 1` and `sm_competitive_fade_enabled 0` to enable players to spectate their teammates only in 3rd person, and not be able to use freecam etc. Useful for semi-competitive gameplay like PUGs so players aren't forced to stare at a black screen.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ before spawning in themselves.
   * Older versions of the nt_competitive plugin use their own built-in (inferior) fade system, which may interfere with this plugin
 
 ## Usage
-Set the cvar value `mp_forcecamera 1` and `sm_competitive_fade_enabled 1` to enable this plugin. The [nt_competitive plugin](https://github.com/Rainyan/sourcemod-nt-competitive) sets this cvar value automatically when going live, so you don't need to do anything if using these plugins in tandem.  
+Set the cvar value `mp_forcecamera 1` and `sm_competitive_fade_enabled 1` (default) to enable this plugin. The [nt_competitive plugin](https://github.com/Rainyan/sourcemod-nt-competitive) sets the cvar `mp_forcecamera 1` automatically when going live, so you don't need to do anything if using these plugins in tandem.  
 
 Set the cvar value `mp_forcecamera 1` and `sm_competitive_fade_enabled 0` to enable players to spectate their teammates only in 3rd person, and not be able to use freecam etc. Useful for semi-competitive gameplay like PUGs so players aren't forced to stare at a black screen.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This plugin blocks any user messages used to remove the fade-to-black effect for
 It also periodically re-draws the fade to ensure it's still being applied.
 
 The plugin will also enable the fade-to-black on new round, so that players can't spectate their opponents' team composition and loadouts
-before spawning in themselves.
+before spawning in themselves.  
+
+Also includes a feature for semi-competitive games where dead players can spectate only their teammates and not be able to use freecam.
 
 ## Compile requirements
 * SourceMod 1.7 or newer.

--- a/scripting/nt_fadefix.sp
+++ b/scripting/nt_fadefix.sp
@@ -120,7 +120,7 @@ public void OnPluginStart()
 
 public Action OnSpecMode(int client, const char[] command, int argc)
 {
-	if (!g_hCvar_FadeEnabled.BoolValue)
+	if (!g_hCvar_FadeEnabled.BoolValue || g_hCvar_CompFadeEnabled.BoolValue)
 	{
 		return Plugin_Continue;
 	}
@@ -144,7 +144,7 @@ public Action OnSpecMode(int client, const char[] command, int argc)
 
 public Action OnSpecPlayer(int client, const char[] command, int argc)
 {
-	if (!g_hCvar_FadeEnabled.BoolValue)
+	if (!g_hCvar_FadeEnabled.BoolValue || g_hCvar_CompFadeEnabled.BoolValue)
 	{
 		return Plugin_Continue;
 	}


### PR DESCRIPTION
Add feature for semi-comp games to allow spectating in a less problematic way than `mp_forcecamera 0`.

If the `sm_competitive_fade_enabled 0` cvar is set, then dead players will be able to spectate only their teammates and not be able to use freecam etc, for minimal chance of exploits, but also more entertaining than a black screen.

Seems to work ok, but maybe it can be achieved in a better way.